### PR TITLE
Bump versions to latest

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,11 +5,11 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
-bazel_dep(name = "platforms", version = "0.0.8")
-bazel_dep(name = "rules_python", version = "1.0.0")
-bazel_dep(name = "rules_uv", version = "0.44.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.5.1")
+bazel_dep(name = "rules_uv", version = "0.86.0")
 
 # configuration
 PYTHON_VERSION = "3.12"

--- a/examples/demo/MODULE.bazel
+++ b/examples/demo/MODULE.bazel
@@ -5,12 +5,12 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_pydeps", version = "0.0.0")
-bazel_dep(name = "rules_python", version = "0.34.0")
-bazel_dep(name = "rules_uv", version = "0.21.0")
+bazel_dep(name = "rules_python", version = "1.5.1")
+bazel_dep(name = "rules_uv", version = "0.86.0")
 
 local_path_override(
     module_name = "rules_pydeps",


### PR DESCRIPTION
Just what the title says.  Update Bazel deps to the latest as of today.  This eliminates pesky build warnings.