### PR TITLE
Migrate to py313

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_uv", version = "0.44.0")
 
 # configuration
-PYTHON_VERSION = "3.12"
+PYTHON_VERSION = "3.13"
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = PYTHON_VERSION)

--- a/pydeps/private/enforcer/BUILD.bazel
+++ b/pydeps/private/enforcer/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@python_versions//3.12:defs.bzl", py_312_binary = "py_binary")
+load("@python_versions//3.13:defs.bzl", py_313_binary = "py_binary")
 load("@rules_pydeps_pip//:requirements.bzl", "requirement")
 
-py_312_binary(
+py_313_binary(
     name = "deps_cli",
     srcs = glob(
         include = ["*.py"],

--- a/pydeps/private/index/BUILD.bazel
+++ b/pydeps/private/index/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@python_versions//3.12:defs.bzl", py_312_binary = "py_binary")
+load("@python_versions//3.13:defs.bzl", py_313_binary = "py_binary")
 load("@rules_pydeps_pip//:requirements.bzl", "requirement")
 
 exports_files(glob(include = ["templates/*.template"]))
 
-py_312_binary(
+py_313_binary(
     name = "index",
     srcs = glob(
         include = ["*.py"],

--- a/pydeps/private/py/BUILD.bazel
+++ b/pydeps/private/py/BUILD.bazel
@@ -4,7 +4,6 @@ load("//pydeps/private/pytest:pytest.bzl", "pytest_test")
 
 py_library(
     name = "py",
-    imports = ["../../.."], # support rules_python 1.7.0 bootstrapping
     srcs = glob(
         include = ["*.py"],
         exclude = ["test_*.py"],

--- a/pydeps/private/py/BUILD.bazel
+++ b/pydeps/private/py/BUILD.bazel
@@ -4,7 +4,7 @@ load("//pydeps/private/pytest:pytest.bzl", "pytest_test")
 
 py_library(
     name = "py",
-    imports = ["../../.."],
+    imports = ["../../.."], # support rules_python 1.7.0 bootstrapping
     srcs = glob(
         include = ["*.py"],
         exclude = ["test_*.py"],

--- a/pydeps/private/py/BUILD.bazel
+++ b/pydeps/private/py/BUILD.bazel
@@ -4,6 +4,7 @@ load("//pydeps/private/pytest:pytest.bzl", "pytest_test")
 
 py_library(
     name = "py",
+    imports = ["../../.."],
     srcs = glob(
         include = ["*.py"],
         exclude = ["test_*.py"],

--- a/pydeps/private/pytest/pytest.bzl
+++ b/pydeps/private/pytest/pytest.bzl
@@ -1,6 +1,6 @@
 "pytest macro"
 
-load("@python_versions//3.12:defs.bzl", "py_test")
+load("@python_versions//3.13:defs.bzl", "py_test")
 
 _TEST_RUNNER_ENTRYPOINT = "//pydeps/private/pytest:runner.py"
 


### PR DESCRIPTION
Bump the python version.

Dependencies appear to work as-is when tested locally.